### PR TITLE
fix: Write os-var replaced .src file to temp file, and rename

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -445,7 +445,7 @@ make_out_file_path() {
 
 # Replace environment variables
 replace_os_vars() {
-    TEMP_OUT=$(mktemp "$2".XXXXX)
+    TEMP_OUT=$(mktemp "$2".XXXXXX)
     awk '{
         while(match($0,"[$]{[^}]*}")) {
             var=substr($0,RSTART+2,RLENGTH -3)

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -445,6 +445,7 @@ make_out_file_path() {
 
 # Replace environment variables
 replace_os_vars() {
+    TEMP_OUT=$(mktemp "$2".XXXXX)
     awk '{
         while(match($0,"[$]{[^}]*}")) {
             var=substr($0,RSTART+2,RLENGTH -3)
@@ -460,7 +461,8 @@ replace_os_vars() {
                 gsub("[$]{"var"}",e)
             }
         }
-    }1' < "$1" > "$2"
+    }1' < "$1" >> "$TEMP_OUT"
+    mv "$TEMP_OUT" "$2"
 }
 
 add_path() {


### PR DESCRIPTION
The replace_os_vars function is called every time for any command, not only those that boot the release. If you call `<release> status` in a readiness check, that will re-write the file.

This might lead to race conditions, where the release starts up, the script creates the replace_os_vars function, is slowed down, but the health check is invoked and it will re-render the sys.config and write it halfway while the starting release gets around to read that very file.

We do see spurios examples of this, where one container out of a bunch on a slow machine start up, and a container that has no changes fail with and error like this

```
2024-04-09 14:46:41.000000000 +0000 forms.nojson: {"message":"could not start kernel pid (application_controller) (error in config file \"/tmp/sys.config\" (none): no ending <dot> found)\r\r"}
```

And this container has a healthcheck implemented with the status command running in it

```
    healthcheck:
      test: [ "CMD", "/opt/forms/bin/forms", "status" ]
```

I do not know if `mktemp` is common enough to use, and portability in general.

